### PR TITLE
Upgrade nltk to version 2.0.5

### DIFF
--- a/simiir/requirements.txt
+++ b/simiir/requirements.txt
@@ -1,6 +1,6 @@
 Whoosh==2.5.5
 lxml==3.2.3
-nltk==2.0.4
+nltk==2.0.5
 progress==1.2
 redis==2.8.0
 requests==2.3.0


### PR DESCRIPTION
Current version in `requirements.txt` refuses to play ball with current version of setuptools.
